### PR TITLE
BUGFIX: Missing funcMap while parsing 'nats-micro-service' template

### DIFF
--- a/generator/runner.go
+++ b/generator/runner.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	_ "embed"
-	"text/template"
 
 	"github.com/jenmud/protoc-gen-go-nats-grpc-adaptor/internal/helpers"
 	"google.golang.org/protobuf/compiler/protogen"
@@ -13,11 +12,6 @@ var templ string
 
 // Run is the main entrypoint.
 func Run() error {
-	tmpl, err := template.New("nats-micro-service").Parse(templ)
-	if err != nil {
-		return err
-	}
-
 	protogen.Options{}.Run(
 		func(gen *protogen.Plugin) error {
 			for _, file := range gen.Files {
@@ -25,7 +19,7 @@ func Run() error {
 					continue
 				}
 
-				if err := helpers.GenerateFile(gen, file, tmpl); err != nil {
+				if err := helpers.GenerateFile(gen, file, templ); err != nil {
 					return err
 				}
 			}

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -123,7 +123,7 @@ func TrimPackagePath(importPath protogen.GoImportPath) string {
 }
 
 // GenerateFile is the main entrypoint used for generating the .pb.go file.
-func GenerateFile(gen *protogen.Plugin, file *protogen.File, tmpl *template.Template) error {
+func GenerateFile(gen *protogen.Plugin, file *protogen.File, tmplStr string) error {
 	if len(file.Services) == 0 {
 		return nil
 	}
@@ -159,7 +159,11 @@ func GenerateFile(gen *protogen.Plugin, file *protogen.File, tmpl *template.Temp
 		},
 	}
 
-	tmpl = template.New("nats-micro-service").Funcs(funcMap)
+	tmpl, err := template.New("nats-micro-service").Funcs(funcMap).Parse(tmplStr)
+	if err != nil {
+		logger.Error("failed to parse the template", slog.String("reason", err.Error()))
+		return err
+	}
 
 	data := struct {
 		*protogen.File


### PR DESCRIPTION
Fix exec with `buf`:

<img width="767" alt="Screenshot 2025-02-03 at 2 06 09 PM" src="https://github.com/user-attachments/assets/ab41a0a5-7794-4ad7-b255-7bd1bd5bdd40" />
Error: failed to parse template: template: nats-micro-service:6: function "formatImports" not defined